### PR TITLE
Correct array indexes

### DIFF
--- a/cleaning-notebooks/02 - String Matching.ipynb
+++ b/cleaning-notebooks/02 - String Matching.ipynb
@@ -90,7 +90,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fuzz.partial_ratio(berlin[2], berlin[3])"
+    "fuzz.partial_ratio(berlin[1], berlin[2])"
    ]
   },
   {
@@ -99,7 +99,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fuzz.ratio(berlin[2], berlin[3])"
+    "fuzz.ratio(berlin[1], berlin[2])"
    ]
   },
   {
@@ -108,7 +108,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fuzz.token_sort_ratio(berlin[2], berlin[3])"
+    "fuzz.token_sort_ratio(berlin[1], berlin[2])"
    ]
   },
   {


### PR DESCRIPTION
In the second string matching section, the second and third
strings in the 'berlin' list were accessed with indexes 2 and 3
rather than 1 and 2.